### PR TITLE
🔥 remove: Remove automatic dark mode support

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -32,12 +32,6 @@
   --font-sans: var(--font-inter, system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: var(--color-night);
-    --foreground: var(--color-milk);
-  }
-}
 
 body {
   background: var(--background);


### PR DESCRIPTION
Remove CSS media query that automatically switched to dark theme based on system preferences. Application now consistently uses light theme only.